### PR TITLE
Pull request: Update Japanese Translation on 16 Dec, 2019

### DIFF
--- a/Languages/Japanese/Keyed/Alerts.xml
+++ b/Languages/Japanese/Keyed/Alerts.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
+  <ExtraAlerts_ModName>Extra Alerts</ExtraAlerts_ModName>
+
   <AlertNotBondedAnimalMaster>動物(絆)の主人が違う</AlertNotBondedAnimalMaster>
   <AlertNotBondedAnimalMasterDesc>絆で結ばれた主人に動物が割り当てられていません</AlertNotBondedAnimalMasterDesc>
 


### PR DESCRIPTION
add ExtraAlerts_ModName.
This is because if there is no description in the Japanese translation file, it will be garbled due to character encoding.