### PR TITLE
Fixed mis-spelling

### DIFF
--- a/Languages/English/Keyed/Alerts.xml
+++ b/Languages/English/Keyed/Alerts.xml
@@ -71,7 +71,7 @@
   <AlertTradeCaravanDesc>A trader is visiting</AlertTradeCaravanDesc>
   
   <AlertOrbitalTrader>Orbital trader</AlertOrbitalTrader>
-  <AlertOrbitalTraderDesc>An orbitral trader is in range</AlertOrbitalTraderDesc>
+  <AlertOrbitalTraderDesc>An orbital trader is in range</AlertOrbitalTraderDesc>
   
   <AlertEnemiesOnMap>Enemies</AlertEnemiesOnMap>
   <AlertEnemiesOnMapDesc>There are enemies here, stay safe.</AlertEnemiesOnMapDesc>


### PR DESCRIPTION
Orbital was misspelled as "orbitral"