### PR TITLE
Implement some optimizations

### DIFF
--- a/1.6/Source/Z_MoreAlerts/Alert_AllyNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_AllyNeedsRescue.cs
@@ -14,22 +14,14 @@ namespace Z_MoreAlerts
         {
             get
             {
-                foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.Humanlike && p.Faction != null && p.Faction != Faction.OfPlayer).ToList())
+                foreach (Pawn p in Utility.SpawnedAllies)
                 {
-                    if (!p.IsPrisoner && p.Faction.AllyOrNeutralTo(Faction.OfPlayer))
+                    if (p.RaceProps.Humanlike && !p.IsPrisoner && Utility.NeedsRescue(p))
                     {
-                        if (Alert_EnemiesOnMap.NeedsRescue(p))
-                        {
-                            yield return p;
-                        }
+                        yield return p;
                     }
                 }
             }
-        }
-
-        public static bool NeedsRescue(Pawn p)
-        {
-            return p.Downed && !p.InBed() && !(p.ParentHolder is Pawn_CarryTracker) && (p.jobs.jobQueue == null || p.jobs.jobQueue.Count <= 0 || !p.jobs.jobQueue.Peek().job.CanBeginNow(p, false));
         }
 
         public override string GetLabel()

--- a/1.6/Source/Z_MoreAlerts/Alert_AllyNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_AllyNeedsRescue.cs
@@ -10,17 +10,23 @@ namespace Z_MoreAlerts
 {
     public class Alert_AllyNeedsRescue : Alert_SemiCritical
     {
-        private IEnumerable<Pawn> AlliesNeedingRescue
+        private readonly List<Pawn> alliesNeedingRescue = new List<Pawn>();
+
+        private List<Pawn> AlliesNeedingRescue
         {
             get
             {
+                alliesNeedingRescue.Clear();
+
                 foreach (Pawn p in Utility.SpawnedAllies)
                 {
                     if (p.RaceProps.Humanlike && !p.IsPrisoner && Utility.NeedsRescue(p))
                     {
-                        yield return p;
+                        alliesNeedingRescue.Add(p);
                     }
                 }
+
+                return alliesNeedingRescue;
             }
         }
 
@@ -31,7 +37,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            return string.Format("AlertAllyNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.AlliesNeedingRescue));
+            return string.Format("AlertAllyNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.alliesNeedingRescue));
         }
 
         public override AlertReport GetReport()
@@ -40,7 +46,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.AlliesNeedingRescue.ToList());
+            return AlertReport.CulpritsAre(this.AlliesNeedingRescue);
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Alert_AllyNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_AllyNeedsRescue.cs
@@ -39,12 +39,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in this.AlliesNeedingRescue)
-            {
-                stringBuilder.AppendLine("    " + current.LabelShort);
-            }
-            return string.Format("AlertAllyNeedsRescueDesc".Translate(), stringBuilder.ToString());
+            return string.Format("AlertAllyNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.AlliesNeedingRescue));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Alert_AnimalHeatstroke.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_AnimalHeatstroke.cs
@@ -17,12 +17,11 @@ namespace Z_MoreAlerts
             get
             {
                 this.heatstrokeAnimalsResult.Clear();
-                List<Pawn> allMaps_Spawned = PawnsFinder.AllMaps_Spawned.ToList();
-                for (int i = 0; i < allMaps_Spawned.Count; i++)
+                foreach (var animal in Utility.SpawnedColonyAnimals)
                 {
-                    if (allMaps_Spawned[i].RaceProps.Animal && allMaps_Spawned[i].Faction == Faction.OfPlayer && allMaps_Spawned[i].health.hediffSet.GetFirstHediffOfDef(HediffDefOf.Heatstroke, false)?.CurStageIndex >= 2)
+                    if (animal.health.hediffSet.GetFirstHediffOfDef(HediffDefOf.Heatstroke, false)?.CurStageIndex >= 2)
                     {
-                        this.heatstrokeAnimalsResult.Add(allMaps_Spawned[i]);
+                        this.heatstrokeAnimalsResult.Add(animal);
                     }
                 }
                 return this.heatstrokeAnimalsResult;

--- a/1.6/Source/Z_MoreAlerts/Alert_AnimalHypothermia.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_AnimalHypothermia.cs
@@ -17,12 +17,11 @@ namespace Z_MoreAlerts
             get
             {
                 this.hypothermicAnimalsResult.Clear();
-                List<Pawn> allMaps_Spawned = PawnsFinder.AllMaps_Spawned.ToList();
-                for (int i = 0; i < allMaps_Spawned.Count; i++)
+                foreach (var animal in Utility.SpawnedColonyAnimals)
                 {
-                    if (allMaps_Spawned[i].RaceProps.Animal && allMaps_Spawned[i].Faction == Faction.OfPlayer && allMaps_Spawned[i].health.hediffSet.GetFirstHediffOfDef(HediffDefOf.Hypothermia, false)?.CurStageIndex >= 2)
+                    if (animal.health.hediffSet.GetFirstHediffOfDef(HediffDefOf.Hypothermia, false)?.CurStageIndex >= 2)
                     {
-                        this.hypothermicAnimalsResult.Add(allMaps_Spawned[i]);
+                        this.hypothermicAnimalsResult.Add(animal);
                     }
                 }
                 return this.hypothermicAnimalsResult;

--- a/1.6/Source/Z_MoreAlerts/Alert_AsceticBedroomQuality.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_AsceticBedroomQuality.cs
@@ -7,6 +7,8 @@ namespace Z_MoreAlerts
 {
     public class Alert_AsceticBedroomQuality : Alert
     {
+        private readonly List<Pawn> affectedPawns = new List<Pawn>();
+
         public Alert_AsceticBedroomQuality()
         {
             this.defaultLabel = "AlertAsceticBedroomQuality".Translate();
@@ -20,13 +22,15 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.AffectedPawns().ToList());
+            return AlertReport.CulpritsAre(this.AffectedPawns());
         }
 
         private static List<Thought> tmpThoughts = new List<Thought>();
 
-        private IEnumerable<Pawn> AffectedPawns()
+        private List<Pawn> AffectedPawns()
         {
+            affectedPawns.Clear();
+
             foreach (Pawn p in PawnsFinder.AllMapsCaravansAndTravellingTransporters_Alive_FreeColonists_NoCryptosleep)
             {
                 if (p.Dead)
@@ -43,9 +47,9 @@ namespace Z_MoreAlerts
                         {
                             if (Alert_AsceticBedroomQuality.tmpThoughts[i].def == requiredDef)
                             {
-                                if(tmpThoughts[i].CurStageIndex >= 5)
+                                if (tmpThoughts[i].CurStageIndex >= 5)
                                 {
-                                    yield return p;
+                                    affectedPawns.Add(p);
                                 }
                             }
                         }
@@ -57,6 +61,8 @@ namespace Z_MoreAlerts
                     }
                 }
             }
+
+            return affectedPawns;
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Alert_Blight.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_Blight.cs
@@ -11,11 +11,16 @@ namespace Z_MoreAlerts
 {
     public class Alert_Blight : Alert_Critical
     {
-        private IEnumerable<Thing> BlightedPlants
+        private readonly List<Thing> blightedPlants = new List<Thing>();
+
+        private List<Thing> BlightedPlants
         {
             get
             {
                 List<Map> maps = Find.Maps;
+
+                blightedPlants.Clear();
+
                 for (int i = 0; i < maps.Count; i++)
                 {
                     List<Thing> plants = maps[i].listerThings.ThingsInGroup(ThingRequestGroup.HarvestablePlant);
@@ -26,12 +31,14 @@ namespace Z_MoreAlerts
                         {
                             if ((p as Plant)?.Blight != null)
                             {
-                                yield return p;
+                                blightedPlants.Add(p);
                             }
                         }
                     }
-                    
+
                 }
+
+                return blightedPlants;
             }
         }
 
@@ -41,7 +48,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.BlightedPlants.ToList());
+            return AlertReport.CulpritsAre(this.BlightedPlants);
         }
 
         public override string GetLabel()

--- a/1.6/Source/Z_MoreAlerts/Alert_EnemiesOnMap.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EnemiesOnMap.cs
@@ -10,17 +10,23 @@ namespace Z_MoreAlerts
 {
     public class Alert_EnemiesOnMap : Alert_Critical
     {
-        private IEnumerable<Pawn> Enemies
+        private readonly List<Pawn> enemies = new List<Pawn>();
+
+        private List<Pawn> Enemies
         {
             get
             {
+                enemies.Clear();
+
                 foreach (Pawn p in Utility.SpawnedEnemies)
                 {
                     if (!p.Downed && !Alert_HiddenEnemiesOnMap.IsHidden(p))
                     {
-                        yield return p;
+                        enemies.Add(p);
                     }
                 }
+
+                return enemies;
             }
         }
 
@@ -31,7 +37,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            return string.Format("AlertEnemiesDesc".Translate(), this.Enemies.Count(), Utility.BuildPawnListText(this.Enemies));
+            return string.Format("AlertEnemiesDesc".Translate(), this.enemies.Count, Utility.BuildPawnListText(this.enemies));
         }
 
         public override AlertReport GetReport()
@@ -40,7 +46,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.Enemies.ToList());
+            return AlertReport.CulpritsAre(this.Enemies);
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Alert_EnemiesOnMap.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EnemiesOnMap.cs
@@ -14,23 +14,14 @@ namespace Z_MoreAlerts
         {
             get
             {
-                foreach (Pawn p in PawnsFinder.AllMaps_Spawned)
+                foreach (Pawn p in Utility.SpawnedEnemies)
                 {
-                    if (p.HostileTo(Faction.OfPlayer) && !p.Downed)
+                    if (!p.Downed && !Alert_HiddenEnemiesOnMap.IsHidden(p))
                     {
-                        if (!Alert_HiddenEnemiesOnMap.IsHidden(p))
-                        {
-                            yield return p;
-
-                        }
+                        yield return p;
                     }
                 }
             }
-        }
-
-        public static bool NeedsRescue(Pawn p)
-        {
-            return p.Downed && !p.InBed() && !(p.ParentHolder is Pawn_CarryTracker) && (p.jobs.jobQueue == null || p.jobs.jobQueue.Count <= 0 || !p.jobs.jobQueue.Peek().job.CanBeginNow(p, false));
         }
 
         public override string GetLabel()

--- a/1.6/Source/Z_MoreAlerts/Alert_EnemiesOnMap.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EnemiesOnMap.cs
@@ -18,7 +18,7 @@ namespace Z_MoreAlerts
                 {
                     if (p.HostileTo(Faction.OfPlayer) && !p.Downed)
                     {
-                        if(!Alert_HiddenEnemiesOnMap.IsHidden(p))
+                        if (!Alert_HiddenEnemiesOnMap.IsHidden(p))
                         {
                             yield return p;
 
@@ -40,12 +40,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in this.Enemies)
-            {
-                stringBuilder.AppendLine("    " + current.LabelShort);
-            }
-            return string.Format("AlertEnemiesDesc".Translate(), this.Enemies.Count(), stringBuilder.ToString());
+            return string.Format("AlertEnemiesDesc".Translate(), this.Enemies.Count(), Utility.BuildPawnListText(this.Enemies));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Alert_EnemyNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EnemyNeedsRescue.cs
@@ -30,12 +30,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in this.EnemiesNeedingRescue)
-            {
-                stringBuilder.AppendLine("    " + current.LabelShort);
-            }
-            return string.Format("AlertEnemyNeedsRescueDesc".Translate(), stringBuilder.ToString());
+            return string.Format("AlertEnemyNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.EnemiesNeedingRescue));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Alert_EnemyNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EnemyNeedsRescue.cs
@@ -9,17 +9,23 @@ namespace Z_MoreAlerts
 {
     public class Alert_EnemyNeedsRescue : Alert_SemiCritical
     {
-        private IEnumerable<Pawn> EnemiesNeedingRescue
+        private readonly List<Pawn> enemiesNeedingRescue = new List<Pawn>();
+
+        private List<Pawn> EnemiesNeedingRescue
         {
             get
             {
+                enemiesNeedingRescue.Clear();
+
                 foreach (Pawn p in Utility.SpawnedEnemies)
                 {
                     if (Utility.NeedsRescue(p))
                     {
-                        yield return p;
+                        enemiesNeedingRescue.Add(p);
                     }
                 }
+
+                return enemiesNeedingRescue;
             }
         }
 
@@ -30,7 +36,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            return string.Format("AlertEnemyNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.EnemiesNeedingRescue));
+            return string.Format("AlertEnemyNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.enemiesNeedingRescue));
         }
 
         public override AlertReport GetReport()
@@ -39,7 +45,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.EnemiesNeedingRescue.ToList());
+            return AlertReport.CulpritsAre(this.EnemiesNeedingRescue);
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Alert_EnemyNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EnemyNeedsRescue.cs
@@ -13,9 +13,9 @@ namespace Z_MoreAlerts
         {
             get
             {
-                foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.Humanlike && p.HostileTo(Faction.OfPlayer)))
+                foreach (Pawn p in Utility.SpawnedEnemies)
                 {
-                    if (Alert_EnemiesOnMap.NeedsRescue(p))
+                    if (Utility.NeedsRescue(p))
                     {
                         yield return p;
                     }

--- a/1.6/Source/Z_MoreAlerts/Alert_EntityDowned.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EntityDowned.cs
@@ -15,7 +15,7 @@ namespace Z_MoreAlerts
             {
                 //foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.IsAnomalyEntity && p.HostileTo(Faction.OfPlayer)))
                 foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.IsAnomalyEntity))
-                    {
+                {
                     if (Alert_EnemiesOnMap.NeedsRescue(p))
                     {
                         yield return p;
@@ -31,12 +31,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in this.EntitiesDowned)
-            {
-                stringBuilder.AppendLine("    " + current.LabelShort);
-            }
-            return string.Format("AlertEntityDownedDesc".Translate(), stringBuilder.ToString());
+            return string.Format("AlertEntityDownedDesc".Translate(), Utility.BuildPawnListText(this.EntitiesDowned));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Alert_EntityDowned.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EntityDowned.cs
@@ -9,18 +9,24 @@ namespace Z_MoreAlerts
 {
     public class Alert_EntitiesDowned : Alert_SemiCritical
     {
-        private IEnumerable<Pawn> EntitiesDowned
+        private readonly List<Pawn> entitiesDowned = new List<Pawn>();
+
+        private List<Pawn> EntitiesDowned
         {
             get
             {
+                entitiesDowned.Clear();
+
                 //foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.IsAnomalyEntity && p.HostileTo(Faction.OfPlayer)))
                 foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.IsAnomalyEntity))
                 {
                     if (Utility.NeedsRescue(p))
                     {
-                        yield return p;
+                        entitiesDowned.Add(p);
                     }
                 }
+
+                return entitiesDowned;
             }
         }
 
@@ -31,7 +37,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            return string.Format("AlertEntityDownedDesc".Translate(), Utility.BuildPawnListText(this.EntitiesDowned));
+            return string.Format("AlertEntityDownedDesc".Translate(), Utility.BuildPawnListText(this.entitiesDowned));
         }
 
         public override AlertReport GetReport()
@@ -40,7 +46,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.EntitiesDowned.ToList());
+            return AlertReport.CulpritsAre(this.EntitiesDowned);
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Alert_EntityDowned.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_EntityDowned.cs
@@ -16,7 +16,7 @@ namespace Z_MoreAlerts
                 //foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.IsAnomalyEntity && p.HostileTo(Faction.OfPlayer)))
                 foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.IsAnomalyEntity))
                 {
-                    if (Alert_EnemiesOnMap.NeedsRescue(p))
+                    if (Utility.NeedsRescue(p))
                     {
                         yield return p;
                     }

--- a/1.6/Source/Z_MoreAlerts/Alert_HiddenEnemiesOnMap.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_HiddenEnemiesOnMap.cs
@@ -14,16 +14,11 @@ namespace Z_MoreAlerts
         {
             get
             {
-                foreach (Pawn p in PawnsFinder.AllMaps_Spawned)
+                foreach (Pawn p in Utility.SpawnedEnemies)
                 {
-                    if (p.HostileTo(Faction.OfPlayer) && !p.Downed)
+                    if (!p.Downed && IsHidden(p))
                     {
-                        if (IsHidden(p))
-                        {
-                            yield return p;
-
-                        }
-
+                        yield return p;
                     }
                 }
             }

--- a/1.6/Source/Z_MoreAlerts/Alert_HiddenEnemiesOnMap.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_HiddenEnemiesOnMap.cs
@@ -18,7 +18,7 @@ namespace Z_MoreAlerts
                 {
                     if (p.HostileTo(Faction.OfPlayer) && !p.Downed)
                     {
-                        if(IsHidden(p))
+                        if (IsHidden(p))
                         {
                             yield return p;
 
@@ -59,12 +59,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in this.Enemies)
-            {
-                stringBuilder.AppendLine("    " + current.LabelShort);
-            }
-            return string.Format("AlertHiddenEnemiesDesc".Translate(), this.Enemies.Count(), stringBuilder.ToString());
+            return string.Format("AlertHiddenEnemiesDesc".Translate(), this.Enemies.Count(), Utility.BuildPawnListText(this.Enemies));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Alert_HiddenEnemiesOnMap.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_HiddenEnemiesOnMap.cs
@@ -10,17 +10,23 @@ namespace Z_MoreAlerts
 {
     public class Alert_HiddenEnemiesOnMap : Alert_Critical
     {
-        private IEnumerable<Pawn> Enemies
+        private readonly List<Pawn> enemies = new List<Pawn>();
+
+        private List<Pawn> Enemies
         {
             get
             {
+                enemies.Clear();
+
                 foreach (Pawn p in Utility.SpawnedEnemies)
                 {
                     if (!p.Downed && IsHidden(p))
                     {
-                        yield return p;
+                        enemies.Add(p);
                     }
                 }
+
+                return enemies;
             }
         }
 
@@ -54,7 +60,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            return string.Format("AlertHiddenEnemiesDesc".Translate(), this.Enemies.Count(), Utility.BuildPawnListText(this.Enemies));
+            return string.Format("AlertHiddenEnemiesDesc".Translate(), this.enemies.Count, Utility.BuildPawnListText(this.enemies));
         }
 
         public override AlertReport GetReport()
@@ -63,7 +69,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.Enemies.ToList());
+            return AlertReport.CulpritsAre(this.Enemies);
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Alert_NeutralNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_NeutralNeedsRescue.cs
@@ -32,12 +32,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in this.AlliesNeedingRescue)
-            {
-                stringBuilder.AppendLine("    " + current.LabelShort);
-            }
-            return string.Format("AlertNeutralNeedsRescueDesc".Translate(), stringBuilder.ToString());
+            return string.Format("AlertNeutralNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.AlliesNeedingRescue));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Alert_NeutralNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_NeutralNeedsRescue.cs
@@ -15,9 +15,9 @@ namespace Z_MoreAlerts
         {
             get
             {
-                foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.Humanlike && p.Faction == null))
+                foreach (Pawn p in Utility.SpawnedNeutrals)
                 {
-                    if (Alert_EnemiesOnMap.NeedsRescue(p))
+                    if (p.RaceProps.Humanlike && Utility.NeedsRescue(p))
                     {
                         yield return p;
                     }

--- a/1.6/Source/Z_MoreAlerts/Alert_NeutralNeedsRescue.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_NeutralNeedsRescue.cs
@@ -11,17 +11,23 @@ namespace Z_MoreAlerts
 {
     public class Alert_NeutralNeedsRescue : Alert_SemiCritical
     {
-        private IEnumerable<Pawn> AlliesNeedingRescue
+        private readonly List<Pawn> neutralsNeedingRescue = new List<Pawn>();
+
+        private List<Pawn> NeutralsNeedingRescue
         {
             get
             {
+                neutralsNeedingRescue.Clear();
+
                 foreach (Pawn p in Utility.SpawnedNeutrals)
                 {
                     if (p.RaceProps.Humanlike && Utility.NeedsRescue(p))
                     {
-                        yield return p;
+                        neutralsNeedingRescue.Add(p);
                     }
                 }
+
+                return neutralsNeedingRescue;
             }
         }
 
@@ -32,7 +38,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            return string.Format("AlertNeutralNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.AlliesNeedingRescue));
+            return string.Format("AlertNeutralNeedsRescueDesc".Translate(), Utility.BuildPawnListText(this.neutralsNeedingRescue));
         }
 
         public override AlertReport GetReport()
@@ -41,7 +47,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.AlliesNeedingRescue.ToList());
+            return AlertReport.CulpritsAre(this.NeutralsNeedingRescue);
         }
 
     }

--- a/1.6/Source/Z_MoreAlerts/Alert_TraderOnMap.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_TraderOnMap.cs
@@ -10,18 +10,23 @@ namespace Z_MoreAlerts
 {
     public class Alert_TraderOnMap : Alert
     {
+        private readonly List<Pawn> traders = new List<Pawn>();
 
-        private IEnumerable<Pawn> Traders
+        private List<Pawn> Traders
         {
             get
             {
+                traders.Clear();
+
                 foreach (Pawn p in PawnsFinder.AllMaps_Spawned.Where(p => p.RaceProps.Humanlike))
                 {
                     if (p.trader != null && p.trader.CanTradeNow)
                     {
-                        yield return p;
+                        traders.Add(p);
                     }
                 }
+
+                return traders;
             }
         }
 
@@ -32,7 +37,7 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return AlertReport.CulpritsAre(this.Traders.ToList());
+            return AlertReport.CulpritsAre(this.Traders);
         }
 
         public override string GetLabel()

--- a/1.6/Source/Z_MoreAlerts/Alert_TraderOrbital.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_TraderOrbital.cs
@@ -10,28 +10,52 @@ namespace Z_MoreAlerts
 {
     public class Alert_TraderOrbital : Alert
     {
+        private static ThingDef[] commsConsoleDefs;
+        private readonly List<Thing> activeCommsConsoles = new List<Thing>();
 
-        private bool HasOrbitalTrader
+        private static ThingDef[] CommsConsoleDefs
         {
             get
             {
-                List<Map> maps = Find.Maps;
-                for (int i = 0; i < maps.Count; i++)
+                if (commsConsoleDefs == null)
                 {
-                    if (maps[i].passingShipManager.passingShips.Count > 0)
-                    {
-                        List<Building> allBuildingsColonist = maps[i].listerBuildings.allBuildingsColonist;
-                        
-                        if (allBuildingsColonist.Any(b => b.def.defName == "CommsConsole"))
-                        {
-                            return true;
-                        }
-
-
-                    }
-                    
+                    commsConsoleDefs = DefDatabase<ThingDef>.AllDefs.Where(thingDef => thingDef.IsCommsConsole).ToArray();
                 }
-                return false;
+
+                return commsConsoleDefs;
+            }
+        }
+
+        private static bool IsCommsConsoleActive(Thing commsConsole, Faction faction) =>
+            commsConsole.Faction == faction &&
+            ((commsConsole as ThingWithComps)?.GetComp<CompPowerTrader>()?.PowerOn ?? true);
+
+        private List<Thing> ActiveCommsConsoles
+        {
+            get
+            {
+                Faction playerFaction = Faction.OfPlayer;
+
+                activeCommsConsoles.Clear();
+
+                foreach (var map in Find.Maps)
+                {
+                    if (map.passingShipManager.passingShips.Count > 0)
+                    {
+                        foreach (var commsConsoleDef in CommsConsoleDefs)
+                        {
+                            foreach (var commsConsole in map.listerThings.ThingsOfDef(commsConsoleDef))
+                            {
+                                if (IsCommsConsoleActive(commsConsole, playerFaction))
+                                {
+                                    activeCommsConsoles.Add(commsConsole);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return activeCommsConsoles;
             }
         }
 
@@ -41,7 +65,8 @@ namespace Z_MoreAlerts
             {
                 return AlertReport.Inactive;
             }
-            return HasOrbitalTrader;
+
+            return AlertReport.CulpritsAre(ActiveCommsConsoles);
         }
 
         public override string GetLabel()
@@ -51,7 +76,47 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            return "AlertOrbitalTraderDesc".Translate();
+            Map currentMap = Find.CurrentMap;
+            Faction playerFaction = Faction.OfPlayer;
+
+            string detail = Utility.BuildString(stringBuilder =>
+            {
+                foreach (var map in Find.Maps)
+                {
+                    if (map.passingShipManager.passingShips.Count > 0 &&
+                        CommsConsoleDefs.SelectMany(map.listerThings.ThingsOfDef).Any(c => IsCommsConsoleActive(c, playerFaction)))
+                    {
+                        stringBuilder.AppendLine();
+                        stringBuilder.AppendLine();
+
+                        if (map == currentMap)
+                        {
+                            stringBuilder.Append("<b>");
+                        }
+
+                        stringBuilder.Append(map.info.parent.LabelCap.Colorize(map == currentMap ? ColoredText.FactionColor_Ally : ColoredText.FactionColor_Neutral));
+
+                        if (map == currentMap)
+                        {
+                            stringBuilder.Append("</b>");
+                        }
+
+                        stringBuilder.Append(":");
+
+                        foreach (var passingShip in map.passingShipManager.passingShips)
+                        {
+                            stringBuilder.AppendLine();
+                            stringBuilder.AppendLine();
+                            stringBuilder.Append("    ");
+                            stringBuilder.Append(passingShip.FullTitle);
+                            stringBuilder.Append(": ");
+                            stringBuilder.Append(passingShip.ticksUntilDeparture.ToStringTicksToPeriod());
+                        }
+                    }
+                }
+            });
+
+            return "AlertOrbitalTraderDesc".Translate() + detail;
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Alert_UnarmedCombatant.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_UnarmedCombatant.cs
@@ -16,17 +16,14 @@ namespace Z_MoreAlerts
                 unarmedCombatants.Clear();
                 foreach (Pawn p in PawnsFinder.AllMaps_FreeColonistsSpawned)
                 {
-                    if (p.equipment.Primary == null && !p.WorkTagIsDisabled(WorkTags.Violent) && !p.Downed && p.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation))
+                    if (p.equipment.Primary == null &&
+                        !p.WorkTagIsDisabled(WorkTags.Violent) &&
+                        !p.Downed && p.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation) &&
+                        (ExtraAlertSettings.cb_childCombatant || !p.DevelopmentalStage.Juvenile()))
                     {
                         unarmedCombatants.Add(p);
                     }
                 }
-
-                if (!ExtraAlertSettings.cb_childCombatant)
-                {
-                    unarmedCombatants.RemoveAll(c => c.DevelopmentalStage.Juvenile());
-                }
-
 
                 return unarmedCombatants;
             }

--- a/1.6/Source/Z_MoreAlerts/Alert_UnarmedCombatant.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_UnarmedCombatant.cs
@@ -22,7 +22,7 @@ namespace Z_MoreAlerts
                     }
                 }
 
-                if(!ExtraAlertSettings.cb_childCombatant)
+                if (!ExtraAlertSettings.cb_childCombatant)
                 {
                     unarmedCombatants.RemoveAll(c => c.DevelopmentalStage.Juvenile());
                 }
@@ -39,12 +39,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in unarmedCombatants)
-            {
-                stringBuilder.AppendLine("    " + current.NameShortColored.Resolve());
-            }
-            return string.Format("AlertUnarmedCombatantDesc".Translate(), stringBuilder.ToString());
+            return string.Format("AlertUnarmedCombatantDesc".Translate(), Utility.BuildPawnListText(unarmedCombatants));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Alert_UnroofedElectrical.cs
+++ b/1.6/Source/Z_MoreAlerts/Alert_UnroofedElectrical.cs
@@ -10,12 +10,14 @@ namespace Z_MoreAlerts
 {
     public class Alert_UnroofedElectrical : Alert
     {
-        private HashSet<Building> UnroofedBuildings
+        private readonly List<Thing> unroofed = new List<Thing>();
+
+        private List<Thing> UnroofedBuildings
         {
             get
             {
-                HashSet<Building> buildings = new HashSet<Building>();
-                HashSet<Building> unroofed = new HashSet<Building>();
+                HashSet<Building> buildings;
+                unroofed.Clear();
                 List<Map> maps = Find.Maps;
                 for (int i = 0; i < maps.Count; i++)
                 {
@@ -41,11 +43,7 @@ namespace Z_MoreAlerts
                 return AlertReport.Inactive;
             }
 
-            List<Thing> culprits = new List<Thing>();
-            foreach(Building b in this.UnroofedBuildings)
-            {
-                culprits.Add((Thing)b);
-            }
+            List<Thing> culprits = this.UnroofedBuildings;
 
             return AlertReport.CulpritsAre(culprits);
         }

--- a/1.6/Source/Z_MoreAlerts/Odyssey/Alert_PorcupineQuills.cs
+++ b/1.6/Source/Z_MoreAlerts/Odyssey/Alert_PorcupineQuills.cs
@@ -38,12 +38,7 @@ namespace Z_MoreAlerts
 
         public override TaggedString GetExplanation()
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach (Pawn current in pawnsWithQuills)
-            {
-                stringBuilder.AppendLine("    " + current.NameShortColored.Resolve());
-            }
-            return string.Format("AlertPorcupineQuillsDesc".Translate(), stringBuilder.ToString());
+            return string.Format("AlertPorcupineQuillsDesc".Translate(), Utility.BuildPawnListText(pawnsWithQuills));
         }
 
         public override AlertReport GetReport()

--- a/1.6/Source/Z_MoreAlerts/Utility.cs
+++ b/1.6/Source/Z_MoreAlerts/Utility.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Verse;
+
+namespace Z_MoreAlerts
+{
+    static class Utility
+    {
+        static readonly StringBuilder stringBuilder = new StringBuilder();
+
+        public static string BuildString(Action<StringBuilder> f)
+        {
+            var savedLength = stringBuilder.Length;
+
+            try
+            {
+                f(stringBuilder);
+
+                return stringBuilder.ToString(savedLength, stringBuilder.Length - savedLength);
+            }
+            finally
+            {
+                stringBuilder.Length = savedLength;
+            }
+        }
+
+        public static string BuildPawnListText(IEnumerable<Pawn> pawns)
+        {
+            return BuildString(stringBuilder =>
+            {
+                foreach (var pawn in pawns)
+                {
+                    stringBuilder.AppendLine();
+                    stringBuilder.Append("    ");
+                    stringBuilder.Append(pawn.NameShortColored.Resolve());
+                }
+            });
+        }
+    }
+}

--- a/1.6/Source/Z_MoreAlerts/Utility.cs
+++ b/1.6/Source/Z_MoreAlerts/Utility.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using RimWorld;
 using Verse;
 
 namespace Z_MoreAlerts
@@ -36,6 +38,74 @@ namespace Z_MoreAlerts
                     stringBuilder.Append(pawn.NameShortColored.Resolve());
                 }
             });
+        }
+
+        public static bool NeedsRescue(Pawn p)
+        {
+            return p.Downed && !p.InBed() && !(p.ParentHolder is Pawn_CarryTracker) && (p.jobs.jobQueue == null || p.jobs.jobQueue.Count <= 0 || !p.jobs.jobQueue.Peek().job.CanBeginNow(p, false));
+        }
+
+        private static IEnumerable<Pawn> SpawnedPawnsByFactionRelationKind(FactionRelationKind factionRelationKind)
+        {
+            var playerFaction = Faction.OfPlayer;
+
+            foreach (Map map in Find.Maps)
+            {
+                MapPawns mapPawns = map.mapPawns;
+
+                foreach (var faction in Find.FactionManager.AllFactions)
+                {
+                    if (faction != playerFaction && faction.RelationKindWith(playerFaction) == factionRelationKind)
+                    {
+                        foreach (var pawn in mapPawns.SpawnedPawnsInFaction(faction))
+                        {
+                            yield return pawn;
+                        }
+                    }
+                }
+
+                // For pawns without factions.
+                if (factionRelationKind == FactionRelationKind.Neutral)
+                {
+                    foreach (var pawn in mapPawns.SpawnedPawnsInFaction(null))
+                    {
+                        yield return pawn;
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<Pawn> SpawnedAllies => SpawnedPawnsByFactionRelationKind(FactionRelationKind.Ally);
+        public static IEnumerable<Pawn> SpawnedNeutrals => SpawnedPawnsByFactionRelationKind(FactionRelationKind.Neutral);
+
+        public static IEnumerable<Pawn> SpawnedEnemies
+        {
+            get
+            {
+                var playerFaction = Faction.OfPlayer;
+
+                // Not using `SpawnedPawnsByFactionRelationKind` because hostility can also be determined by other factors like mental condition, etc.
+                return PawnsFinder.AllMaps_Spawned.Where(pawn => pawn.HostileTo(playerFaction));
+            }
+        }
+
+        public static IEnumerable<Pawn> SpawnedColonyAnimals
+        {
+            get
+            {
+                var playerFaction = Faction.OfPlayer;
+
+                foreach (var map in Find.Maps)
+                {
+                    foreach (var pawn in map.mapPawns.SpawnedPawnsInFaction(playerFaction))
+                    {
+                        if (pawn.IsAnimal)
+                        {
+                            yield return pawn;
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/1.6/Source/Z_MoreAlerts/Z_MoreAlerts.csproj
+++ b/1.6/Source/Z_MoreAlerts/Z_MoreAlerts.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Alert_WantToSleepWith.cs" />
     <Compile Include="ExtraAlertSettings.cs" />
     <Compile Include="MoreAlertsDefOf.cs" />
+    <Compile Include="Utility.cs" />
     <Compile Include="Odyssey\Alert_PorcupineQuills.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Languages/ChineseSimplified/Keyed/Alerts.xml
+++ b/Languages/ChineseSimplified/Keyed/Alerts.xml
@@ -7,23 +7,23 @@
   <ExtraAlerts_Urgent>紧急</ExtraAlerts_Urgent>
 
   <AlertEnemies>敌对敌人</AlertEnemies>
-  <AlertEnemiesDesc>在地图中发现了{0}名敌人。\n\n 请考虑让你的殖民者躲避他们，或者将他们清除掉。</AlertEnemiesDesc>
+  <AlertEnemiesDesc>在地图中发现了{0}名敌人。\n\n 请考虑让你的殖民者躲避他们，或者将他们清除掉：\n{1}</AlertEnemiesDesc>
 
   <AlertHiddenEnemies>隐蔽的敌人</AlertHiddenEnemies>
-  <AlertHiddenEnemiesDesc>地图上有{0}名隐藏中的敌人:\n\n{1}</AlertHiddenEnemiesDesc>
+  <AlertHiddenEnemiesDesc>地图上有{0}名隐藏中的敌人:\n{1}</AlertHiddenEnemiesDesc>
   <AlertHiddenEnemiesLabel>显示隐藏中的敌人，包括战争迷雾中、以及有隐形等手段透明化的敌人。</AlertHiddenEnemiesLabel>
 
   <AlertEnemyNeedsRescue>敌人倒地</AlertEnemyNeedsRescue>
-  <AlertEnemyNeedsRescueDesc>这些都是被击败可"腐乳"的敌人。 你可以让捕捉他们为囚犯、趁机洗劫装备、或者将其无害化：\n\n{0}</AlertEnemyNeedsRescueDesc>
+  <AlertEnemyNeedsRescueDesc>这些都是被击败可"腐乳"的敌人。 你可以让捕捉他们为囚犯、趁机洗劫装备、或者将其无害化：\n{0}</AlertEnemyNeedsRescueDesc>
   
   <AlertEntityDowned>实体倒地</AlertEntityDowned>
   <AlertEntityDownedDesc>这些实体已经暂时失去了行动能力。你可以准备进行收容或处理他们：\n\n{0}</AlertEntityDownedDesc>
 
   <AlertAllyNeedsRescue>盟友倒地</AlertAllyNeedsRescue>
-  <AlertAllyNeedsRescueDesc>这些盟友失去了行动能力。你可以考虑去救援他们：\n\n{0}</AlertAllyNeedsRescueDesc>
+  <AlertAllyNeedsRescueDesc>这些盟友失去了行动能力。你可以考虑去救援他们：\n{0}</AlertAllyNeedsRescueDesc>
   
   <AlertNeutralNeedsRescue>倒地无派别人员</AlertNeutralNeedsRescue>
-  <AlertNeutralNeedsRescueDesc>这些人是无派别的没有行动能力者。 你可以考虑救援或捕获他们：\n\n{0}</AlertNeutralNeedsRescueDesc>
+  <AlertNeutralNeedsRescueDesc>这些人是无派别的没有行动能力者。 你可以考虑救援或捕获他们：\n{0}</AlertNeutralNeedsRescueDesc>
   
   <AlertBlight>枯萎病</AlertBlight>
   <AlertBlightDesc>这些植物已经枯萎了! 在它蔓延之前砍掉它们。</AlertBlightDesc>
@@ -36,10 +36,10 @@
   <AlertNotBondedAnimalMasterDesc>动物并没有被分配给其羁绊的定居者。</AlertNotBondedAnimalMasterDesc>
   
   <AlertDeadMansApparel>死者衣服</AlertDeadMansApparel>
-  <AlertDeadMansApparelDesc>这些定居者穿的是死人的衣服，他们感到不适：\n\n{0}\n请给他们穿上干净的衣服。</AlertDeadMansApparelDesc>
+  <AlertDeadMansApparelDesc>这些定居者穿的是死人的衣服，他们感到不适：\n{0}\n\n请给他们穿上干净的衣服。</AlertDeadMansApparelDesc>
   
   <AlertHumanLeatherApparelSad>人皮衣服</AlertHumanLeatherApparelSad>
-  <AlertHumanLeatherApparelSadDesc>这些殖民者穿着人类皮革服装，他们感觉很不安：\n\n{0}\n可以尝试他们穿上其他材质的衣服。</AlertHumanLeatherApparelSadDesc>
+  <AlertHumanLeatherApparelSadDesc>这些殖民者穿着人类皮革服装，他们感觉很不安：\n{0}\n\n可以尝试他们穿上其他材质的衣服。</AlertHumanLeatherApparelSadDesc>
 
   <AlertWantToSleepWith>异地恋恋人</AlertWantToSleepWith>
   <AlertWantToSleepWithDesc>这些定居者想和她的恋人在一起。请考虑给他们分配一套住房（双人床）吧。\n\n除了出轨者——他这个骗子!</AlertWantToSleepWithDesc>

--- a/Languages/English/Keyed/Alerts.xml
+++ b/Languages/English/Keyed/Alerts.xml
@@ -7,23 +7,23 @@
   <ExtraAlerts_Urgent>Urgent</ExtraAlerts_Urgent>
   
   <AlertEnemies>Enemies</AlertEnemies>
-  <AlertEnemiesDesc>There are {0} enemies active on the map:\n\n{1}</AlertEnemiesDesc>
+  <AlertEnemiesDesc>There are {0} enemies active on the map:\n{1}</AlertEnemiesDesc>
   
   <AlertHiddenEnemies>Hidden enemies</AlertHiddenEnemies>
-  <AlertHiddenEnemiesDesc>There are {0} enemies hiding on the map:\n\n{1}</AlertHiddenEnemiesDesc>
+  <AlertHiddenEnemiesDesc>There are {0} enemies hiding on the map:\n{1}</AlertHiddenEnemiesDesc>
   <AlertHiddenEnemiesLabel>Show hidden enemies. Includes enemies in fogged areas, as well as invisible sightstealers.</AlertHiddenEnemiesLabel>
   
   <AlertEnemyNeedsRescue>Enemy downed</AlertEnemyNeedsRescue>
-  <AlertEnemyNeedsRescueDesc>These enemies are incapacitated. You can capture them, strip them, or finish them off:\n\n{0}</AlertEnemyNeedsRescueDesc>
+  <AlertEnemyNeedsRescueDesc>These enemies are incapacitated. You can capture them, strip them, or finish them off:\n{0}</AlertEnemyNeedsRescueDesc>
   
   <AlertEntityDowned>Entity downed</AlertEntityDowned>
-  <AlertEntityDownedDesc>These anomalous entites are incapacitated. You can capture them or finish them off:\n\n{0}</AlertEntityDownedDesc>
+  <AlertEntityDownedDesc>These anomalous entites are incapacitated. You can capture them or finish them off:\n{0}</AlertEntityDownedDesc>
   
   <AlertAllyNeedsRescue>Ally downed</AlertAllyNeedsRescue>
-  <AlertAllyNeedsRescueDesc>These allies are incapacitated. You might want to rescue them:\n\n{0}</AlertAllyNeedsRescueDesc>
+  <AlertAllyNeedsRescueDesc>These allies are incapacitated. You might want to rescue them:\n{0}</AlertAllyNeedsRescueDesc>
   
   <AlertNeutralNeedsRescue>Humanoid downed</AlertNeutralNeedsRescue>
-  <AlertNeutralNeedsRescueDesc>These neutral people are incapacitated. You might want to rescue or capture them:\n\n{0}</AlertNeutralNeedsRescueDesc>
+  <AlertNeutralNeedsRescueDesc>These neutral people are incapacitated. You might want to rescue or capture them:\n{0}</AlertNeutralNeedsRescueDesc>
   
   <AlertBlight>Blight</AlertBlight>
   <AlertBlightDesc>These plants are blighted! Cut them before it spreads.</AlertBlightDesc>
@@ -36,10 +36,10 @@
   <AlertNotBondedAnimalMasterDesc>An animal is not assigned to its bonded master.</AlertNotBondedAnimalMasterDesc>
   
   <AlertDeadMansApparel>Tainted apparel</AlertDeadMansApparel>
-  <AlertDeadMansApparelDesc>These colonists are wearing apparel from a corpse, which is making them sad:\n\n{0}\nGet them some clean clothing.</AlertDeadMansApparelDesc>
+  <AlertDeadMansApparelDesc>These colonists are wearing apparel from a corpse, which is making them sad:\n{0}\n\nGet them some clean clothing.</AlertDeadMansApparelDesc>
   
   <AlertHumanLeatherApparelSad>Unhappy human leather</AlertHumanLeatherApparelSad>
-  <AlertHumanLeatherApparelSadDesc>These colonists are wearing human leather apparel, which they find disturbing:\n\n{0}\nGet them clothing made of something else.</AlertHumanLeatherApparelSadDesc>
+  <AlertHumanLeatherApparelSadDesc>These colonists are wearing human leather apparel, which they find disturbing:\n{0}\n\nGet them clothing made of something else.</AlertHumanLeatherApparelSadDesc>
 
   <AlertWantToSleepWith>Lovers separated</AlertWantToSleepWith>
   <AlertWantToSleepWithDesc>These colonists want to sleep together. Consider assigning them a double bed.</AlertWantToSleepWithDesc>
@@ -78,7 +78,7 @@
   <AlertUnroofedElectricalDesc>These buildings are unroofed and will short circuit in rain.</AlertUnroofedElectricalDesc>
   
   <AlertUnarmedCombatant>Combatant unarmed</AlertUnarmedCombatant>
-  <AlertUnarmedCombatantDesc>These colonists are combat-capable, but lack weapons:\n\n{0}</AlertUnarmedCombatantDesc>
+  <AlertUnarmedCombatantDesc>These colonists are combat-capable, but lack weapons:\n{0}</AlertUnarmedCombatantDesc>
   <AlertChildCombatant>Include child combatants</AlertChildCombatant>
   <AlertChildCombatantDesc>If enabled, this alert will include unarmed children.</AlertChildCombatantDesc>
   
@@ -95,7 +95,7 @@
  <ExtraAlerts_Odyssey>Odyssey</ExtraAlerts_Odyssey>
  
  <AlertPorcupineQuills>Porcupine quills</AlertPorcupineQuills>
- <AlertPorcupineQuillsDesc>These colonists have porcupine quills embedded in their skin. These are painful, and last until surgically removed:\n\n{0}</AlertPorcupineQuillsDesc>
+ <AlertPorcupineQuillsDesc>These colonists have porcupine quills embedded in their skin. These are painful, and last until surgically removed:\n{0}</AlertPorcupineQuillsDesc>
   
   
 </LanguageData>

--- a/Languages/French/Keyed/Alerts.xml
+++ b/Languages/French/Keyed/Alerts.xml
@@ -7,7 +7,7 @@
   <AlertNotBondedAnimalMasterDesc>Un animal lié n'est pas assigné à son maître.</AlertNotBondedAnimalMasterDesc>
 
   <AlertDeadMansApparel>Vêtements souillés</AlertDeadMansApparel>
-  <AlertDeadMansApparelDesc>Les colons suivants portent des vêtements ayant été portés par un cadavre, ce qui les rends tristes :\n\n{0}\n Donnez-leur des habits propres.</AlertDeadMansApparelDesc>
+  <AlertDeadMansApparelDesc>Les colons suivants portent des vêtements ayant été portés par un cadavre, ce qui les rends tristes :\n{0}\n\n Donnez-leur des habits propres.</AlertDeadMansApparelDesc>
   
   <AlertWantToSleepWith>Amants séparés</AlertWantToSleepWith>
   <AlertWantToSleepWithDesc>Ces colons veulent dormir ensemble. Envisagez de les assigner à un double-lit.</AlertWantToSleepWithDesc>

--- a/Languages/Japanese/Keyed/Alerts.xml
+++ b/Languages/Japanese/Keyed/Alerts.xml
@@ -7,23 +7,23 @@
   <ExtraAlerts_Urgent>緊急</ExtraAlerts_Urgent>
 
   <AlertEnemies>敵対者がいる</AlertEnemies>
-  <AlertEnemiesDesc>活動中の敵をマップ内に{0}体確認しました：\n\n{1}</AlertEnemiesDesc>
+  <AlertEnemiesDesc>活動中の敵をマップ内に{0}体確認しました：\n{1}</AlertEnemiesDesc>
 
   <AlertHiddenEnemies>隠れた敵がいる</AlertHiddenEnemies>
-  <AlertHiddenEnemiesDesc>マップ上に{0}名の敵が隠れています:\n\n{1}</AlertHiddenEnemiesDesc>
+  <AlertHiddenEnemiesDesc>マップ上に{0}名の敵が隠れています:\n{1}</AlertHiddenEnemiesDesc>
   <AlertHiddenEnemiesLabel>隠れた敵を表示します.戦場の霧がかかった地域にいる敵や,透明化しているサイトスティーラーも含まれます.</AlertHiddenEnemiesLabel>
 
   <AlertEnemyNeedsRescue>救助が必要な敵</AlertEnemyNeedsRescue>
-  <AlertEnemyNeedsRescueDesc>無力化された敵です.囚人にしたり,衣服を脱がせたり,トドメを刺したりできます:\n\n{0}</AlertEnemyNeedsRescueDesc>
+  <AlertEnemyNeedsRescueDesc>無力化された敵です.囚人にしたり,衣服を脱がせたり,トドメを刺したりできます:\n{0}</AlertEnemyNeedsRescueDesc>
 
   <AlertEntityDowned>無力化された存在</AlertEntityDowned>
-  <AlertEntityDownedDesc>これらのAnomalyDLCの存在は,無力化されています.捕獲するか,仕留めることができます.\n\n{0}</AlertEntityDownedDesc>
+  <AlertEntityDownedDesc>これらのAnomalyDLCの存在は,無力化されています.捕獲するか,仕留めることができます.\n{0}</AlertEntityDownedDesc>
 
   <AlertAllyNeedsRescue>救助が必要な同盟者</AlertAllyNeedsRescue>
-  <AlertAllyNeedsRescueDesc>無力化された味方です.彼らを救助したほうがいいかもしれません.:\n\n{0}</AlertAllyNeedsRescueDesc>
+  <AlertAllyNeedsRescueDesc>無力化された味方です.彼らを救助したほうがいいかもしれません.:\n{0}</AlertAllyNeedsRescueDesc>
 
   <AlertNeutralNeedsRescue>救助が必要な人</AlertNeutralNeedsRescue>
-  <AlertNeutralNeedsRescueDesc>派閥に属していない無力化された人です.あなたは救出するか捕らえることもできます:\n\n{0}</AlertNeutralNeedsRescueDesc>
+  <AlertNeutralNeedsRescueDesc>派閥に属していない無力化された人です.あなたは救出するか捕らえることもできます:\n{0}</AlertNeutralNeedsRescueDesc>
 
   <AlertBlight>疫病</AlertBlight>
   <AlertBlightDesc>これらの作物に疫病が蔓延する前に,疫病に冒された作物を,刈り取るか焼却するべきです.</AlertBlightDesc>
@@ -36,10 +36,10 @@
   <AlertNotBondedAnimalMasterDesc>絆で結ばれた主人に動物が割り当てられていません.</AlertNotBondedAnimalMasterDesc>
 
   <AlertDeadMansApparel>汚れた衣服を着用</AlertDeadMansApparel>
-  <AlertDeadMansApparelDesc>これらの入植者たちは死人が着ていた服を着ているので,心情が悪化しています：\n\n{0}\n清潔な服を着せてください.</AlertDeadMansApparelDesc>
+  <AlertDeadMansApparelDesc>これらの入植者たちは死人が着ていた服を着ているので,心情が悪化しています：\n{0}\n\n清潔な服を着せてください.</AlertDeadMansApparelDesc>
 
   <AlertHumanLeatherApparelSad>人の皮製品で不幸</AlertHumanLeatherApparelSad>
-  <AlertHumanLeatherApparelSadDesc>これらの入植者たちは人間の皮で出来た衣服を身に着けているので,不幸を感じています:\n\n{0}\n他の素材で作られた衣服を着せてください.</AlertHumanLeatherApparelSadDesc>
+  <AlertHumanLeatherApparelSadDesc>これらの入植者たちは人間の皮で出来た衣服を身に着けているので,不幸を感じています:\n{0}\n\n他の素材で作られた衣服を着せてください.</AlertHumanLeatherApparelSadDesc>
 
   <AlertWantToSleepWith>恋人が別々なベッド</AlertWantToSleepWith>
   <AlertWantToSleepWithDesc>これらの入植者たちは恋人と一緒に寝たいと思っています.ダブルベッドを割り当てることを検討してください.</AlertWantToSleepWithDesc>
@@ -78,7 +78,7 @@
   <AlertUnroofedElectricalDesc>これらの建築物には屋根がなく,雨が降るとショートします.</AlertUnroofedElectricalDesc>
 
   <AlertUnarmedCombatant>戦闘員が非武装</AlertUnarmedCombatant>
-  <AlertUnarmedCombatantDesc>これらの入植者は戦闘可能ですが非武装です:\n\n{0}</AlertUnarmedCombatantDesc>
+  <AlertUnarmedCombatantDesc>これらの入植者は戦闘可能ですが非武装です:\n{0}</AlertUnarmedCombatantDesc>
   <AlertChildCombatant>戦闘員に子供を含む</AlertChildCombatant>
   <AlertChildCombatantDesc>有効にすると,この警告メッセージには非武装の子供も含まれます.</AlertChildCombatantDesc>
 
@@ -95,7 +95,7 @@
  <ExtraAlerts_Odyssey>Odyssey</ExtraAlerts_Odyssey>
 
  <AlertPorcupineQuills>ヤマアラシの針</AlertPorcupineQuills>
- <AlertPorcupineQuillsDesc>これらの入植者たちの皮膚にはヤマアラシの針が刺さっており,それは痛みを伴って外科手術で除去するまで消えません:\n\n{0}</AlertPorcupineQuillsDesc>
+ <AlertPorcupineQuillsDesc>これらの入植者たちの皮膚にはヤマアラシの針が刺さっており,それは痛みを伴って外科手術で除去するまで消えません:\n{0}</AlertPorcupineQuillsDesc>
 
 
 </LanguageData>

--- a/Languages/PortugueseBrazilian/Keyed/Alerts.xml
+++ b/Languages/PortugueseBrazilian/Keyed/Alerts.xml
@@ -26,7 +26,7 @@
   <AlertNotBondedAnimalMasterDesc>Um animal não está designado para seu mestre.</AlertNotBondedAnimalMasterDesc>
   
   <AlertDeadMansApparel>Roupas de defunto</AlertDeadMansApparel>
-  <AlertDeadMansApparelDesc>Estes colonos estão vestindo roupas que alguém morreu usando, que está deixando eles chateados:\n\n{0}\nConsiga roupas limpas para eles.</AlertDeadMansApparelDesc>
+  <AlertDeadMansApparelDesc>Estes colonos estão vestindo roupas que alguém morreu usando, que está deixando eles chateados:\n{0}\n\nConsiga roupas limpas para eles.</AlertDeadMansApparelDesc>
   
   <AlertHumanLeatherApparelSad>Perturbado por pele humana</AlertHumanLeatherApparelSad>
   <AlertHumanLeatherApparelSadDesc>Estes colonos estão vestindo roupas de pele humana, o que eles acham perturbador. Consiga roupas feitas de outra coisa para eles.</AlertHumanLeatherApparelSadDesc>

--- a/Languages/Russian/Keyed/Alerts.xml
+++ b/Languages/Russian/Keyed/Alerts.xml
@@ -25,7 +25,7 @@
   <AlertNotBondedAnimalMasterDesc>Привязанное животное не назначено своему хозяину.</AlertNotBondedAnimalMasterDesc>
 
   <AlertDeadMansApparel>Испорченная одежда</AlertDeadMansApparel>
-  <AlertDeadMansApparelDesc>Эти колонисты носят одежду с трупа, что их очень огорчает:\n\n{0}\nДайте им новую одежду.</AlertDeadMansApparelDesc>
+  <AlertDeadMansApparelDesc>Эти колонисты носят одежду с трупа, что их очень огорчает:\n{0}\n\nДайте им новую одежду.</AlertDeadMansApparelDesc>
 
   <AlertHumanLeatherApparelSad>Одежда из человеческой кожи</AlertHumanLeatherApparelSad>
   <AlertHumanLeatherApparelSadDesc>Эти колонисты одеты в одежду из человеческой кожи, что их беспокоит. Дайте им одежду, сделанную из другого материала.</AlertHumanLeatherApparelSadDesc>


### PR DESCRIPTION
This PR proposes several optimizations to `ExtraAlerts`:

- Avoid unnecessary `ToList()` and `StringBuilder` allocations, reuse existing allocations if possible.
- Find pawns by factions to reduce numbers of pawns to check in later game stages when there are a lot of pawns.
- Remove unnecessary trailing new lines from alert explanations.
- Show orbital trader remaining duration.
- Find comms console by def instead of iterate through all colony buildings for orbital trader alert.
- Comms console now requires to be owned by player faction and properly powered in order to trigger orbital trader alert.
- Exclude neutral pawns from allies to rescue.
- Include pawns from neutral factions to neutrals to rescue, which currently only contains pawns without factions.

Let me know if there are any undesired or incorrect changes and I will fix them.

I grouped changes in this PR into 4 commits, hopefully this can make this PR easier to review.